### PR TITLE
Instructions for installation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,10 @@
+# EVA 2019 Tutorial
+
+This folder contains the slides and datasets from the EVA 2019 R package tutorial.
+
+Since some packages are voluminous, we encourage to install the packages ahead of time using the command
+
+```
+install.packages(c("extRemes","RandomFields","SpatialExtremes","mvPot","mev","revdbayes","cobs"))
+install.packages("INLA", repos=c(getOption("repos"), INLA="https://inla.r-inla-download.org/R/stable"), dep=TRUE)
+```

--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,6 @@ This folder contains the slides and datasets from the EVA 2019 R package tutoria
 Since some packages are voluminous, we encourage to install the packages ahead of time using the command
 
 ```
-install.packages(c("extRemes","RandomFields","SpatialExtremes","mvPot","mev","revdbayes","cobs"))
+install.packages(c("extRemes","RandomFields","SpatialExtremes","mvPot","mev","revdbayes","cobs", "sp", "ggplot2"))
 install.packages("INLA", repos=c(getOption("repos"), INLA="https://inla.r-inla-download.org/R/stable"), dep=TRUE)
 ```


### PR DESCRIPTION
The Windows and OSX binaries for the latest version of `mev` (1.12) are not currently updated on CRAN, so please refrain from advertising now. These should be hopefully up by tomorrow.